### PR TITLE
fix: stop autostart menu loop and persist task reordering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+**System-SL** — a Solo Leveling–themed personal task manager. Stores tasks in JSON under the OS-appropriate user config dir, optionally syncs from Google Calendar/Tasks, and shows desktop notifications. The codebase is mid-transition into a single `system_sl` package (under `src/system_sl/`); the live GUI and console-script entry points both run from there.
+
+## Commands
+
+Dependencies are managed with [uv](https://github.com/astral-sh/uv).
+
+```bash
+uv sync                                  # install deps into .venv
+source .venv/bin/activate                # Linux/macOS  (Windows: .venv\Scripts\activate)
+
+# Run the GUI (current entry point)
+uv run system-sl                         # console script -> system_sl.frontend.gui.main:main
+# or, with PYTHONPATH=src:
+python -m system_sl.frontend.gui.main
+
+# Background notifier only (no menu) — what the autostart systemd unit runs:
+python -m system_sl.frontend.gui.main --bg
+
+# Build a single-file binary
+uv run python build.py                   # PyInstaller, output in dist/
+
+# End-user installer (after building)
+python src/system_sl/utils/install.py    # places binary, creates shortcut, migrates credentials.json
+```
+
+There is no test suite and no linter configured.
+
+### Known-stale invocations
+- **Two source trees coexist.** The canonical code is `src/system_sl/`. Legacy flat copies still sit at `src/cli/`, `src/core/`, `src/gui/`, `src/utils/` — edit the `system_sl` versions, not these.
+- `build.py` still points its PyInstaller entry at the legacy `src/cli/main.py`, while `pyproject.toml`'s console script points at `system_sl.frontend.gui.main:main`. The two disagree; the console script is the live one.
+
+## Architecture
+
+### Layout under `src/system_sl/`
+
+- **`core/`** — pure data/business logic, no UI. `tasks.py` owns JSON persistence for tasks; `prioritization.py` ranks tasks (deadline urgency + persona/goal keyword boost) and persists manual drag-reordering; `sync_service.py` holds the Google sync engine; `onboarding.py`/`user_info.py` build the persona/goal profile.
+- **`utils/`** — side-effect modules. `paths.py:get_tasks_file_path(filename)` is the single path helper every disk access routes through. `autostart.py:AutostartManager` writes/removes `~/.config/systemd/user/sl-notifer.service` (runs the binary with `--bg`, `Restart=always`). `notifications_ui.py:SystemNotification` is a frameless always-on-top widget. `json_client.py` (`load_data`/`save_data`), `google_api.py`, `install.py`.
+- **`services/`** — `background_service.py:BackgroundServiceController` drives the hourly notifier loop (`QTimer` → `get_random_task()` → `SystemNotification.display_message`).
+- **`frontend/gui/`** — PySide6 windows. `main.py:MainWindow` is the shell (and `main()` parses `--bg`); `popup_windows.py:TasksWindow` is the drag-reorderable task list. The GUI is intentionally thin — all state lives in JSON via `core`.
+- **`chatbot/`** — the chat panel's LLM client/config.
+
+### Background notifier / autostart
+
+Enabling "Notification AutoStart" toggles a systemd user unit that relaunches the app with `--bg` and `Restart=always`. `main()` MUST branch on `--bg` to run **only** the notifier (`SystemNotification` + `BackgroundServiceController`); if it opened the main menu instead, `Restart=always` would reopen the menu on every close (an infinite loop).
+
+### Data storage — single source of truth
+
+All user data lives in an OS-specific config directory, **not** in the repo:
+
+- Linux/macOS: `~/.config/system-sl/`   •   Windows: `%APPDATA%/system-sl/`
+
+Files: `tasks.json`, `completed_tasks.json`, `task_order.json` (saved manual reorder), `user_info.json`, `persona.json`, `.setup_complete`, `credentials.json` (user-supplied Google OAuth secret), `token.json` (auto-generated on first sync).
+
+Always route filesystem access through `get_tasks_file_path(filename)` — don't hardcode paths or read the repo's gitignored `demo-data/`.
+
+### Task schema & ordering
+
+`tasks.json` is `{category: [task, ...]}`, each task `{"title": str, "created_at": str, "deadline": str | None}`. `load_tasks()` auto-migrates legacy string entries to dict form and rewrites the file — reading can mutate it. `completed_tasks.json` uses a different shape (`{category: [str, ...]}`, completion date embedded).
+
+`prioritize_tasks()` returns a flat ranked list. `task_order.json` (`{"order": [[category, title], ...]}`) stores the user's manual drag order: tasks listed there keep those positions, anything else trails in score order. `TasksWindow` calls `save_manual_order()` after a drag and re-reads on every `showEvent`.
+
+### Import path convention
+
+Built with `--paths=src`, so the package is imported fully qualified: `from system_sl.core.tasks import ...`, `from system_sl.utils import ...`. Match this in new code; ignore the legacy bare-`core.`/`src.` imports in the dead trees.
+
+### Google Calendar/Tasks sync
+
+`core/sync_service.py` (`GoogleSyncEngine`, `CalendarProvider`, `TasksProvider`) reads `credentials.json` (user generates via Google Cloud Console — see README) and caches `token.json` after the first OAuth flow. Scopes are read-only. Calendar events become category `"calendar"`, Google Tasks become category `"task"`. Duplicates (same title in same category) are silently skipped via `ValueError` in `add_tasks`.

--- a/src/system_sl/core/prioritization.py
+++ b/src/system_sl/core/prioritization.py
@@ -8,6 +8,7 @@ re-ranking (see ``priori.jpeg``).
 from datetime import datetime
 
 from system_sl.core.tasks import load_tasks, get_tasks_file_path, load_data
+from system_sl.utils import save_data
 
 
 # Scoring weights. Tunable — these only affect the *initial* ordering the user
@@ -16,6 +17,9 @@ OVERDUE_SCORE = 100.0   # past-due tasks float to the very top
 SOON_BASE = 50.0        # a task due today scores this; further out scores less
 SOON_HORIZON = 50       # days beyond which "soon" no longer adds urgency
 KEYWORD_BOOST = 10.0    # title matches a persona/goal keyword
+
+# File holding the user's manual drag-reordering, so it survives restarts.
+ORDER_FILE = "task_order.json"
 
 
 def _parse_deadline(value):
@@ -104,10 +108,42 @@ def prioritize_tasks(tasks=None):
     # Highest score first; older tasks then alphabetical for stable ties.
     scored.sort(key=lambda t: (-t["score"], t["created_at"], t["title"]))
 
+    # Apply any saved manual ordering. Tasks the user has dragged keep their
+    # chosen positions; anything not in the saved order (e.g. newly added or
+    # synced tasks) follows after, still in score order. Both sorts are stable,
+    # so the score order is preserved among the trailing tasks.
+    manual = load_manual_order()
+    if manual:
+        pos = {(cat, title): i for i, (cat, title) in enumerate(manual)}
+        scored.sort(
+            key=lambda t: pos.get((t["category"], t["title"]), len(pos))
+        )
+
     for rank, task in enumerate(scored, start=1):
         task["rank"] = rank
 
     return scored
+
+
+def load_manual_order():
+    """Return the saved manual order as a list of ``[category, title]`` pairs.
+
+    Empty list if the user has never reordered (or the file is missing/empty).
+    """
+    data = load_data(get_tasks_file_path(ORDER_FILE))
+    if not isinstance(data, dict):
+        return []
+    return data.get("order", [])
+
+
+def save_manual_order(tasks):
+    """Persist the current display order so a manual drag survives restarts.
+
+    ``tasks`` is the ordered list of task dicts currently shown; only each
+    task's ``(category, title)`` identity is stored.
+    """
+    order = [[t.get("category", ""), t.get("title", "")] for t in tasks]
+    save_data(get_tasks_file_path(ORDER_FILE), {"order": order})
 
 
 def record_reorder_feedback(moved_title, old_rank, new_rank, new_order):

--- a/src/system_sl/frontend/gui/main.py
+++ b/src/system_sl/frontend/gui/main.py
@@ -6,8 +6,9 @@ from PySide6.QtWidgets import QApplication, QMainWindow, QWidget, QPushButton, Q
 from system_sl.frontend.gui.popup_windows import TasksWindow
 from system_sl.frontend.gui.chat_panel import ChatPanel
 from system_sl.frontend.gui.theme import SOLO_LEVELING_QSS
-from system_sl.utils import AutostartManager
+from system_sl.utils import AutostartManager, SystemNotification
 from system_sl.core import GoogleSyncEngine, CalendarProvider, TasksProvider
+from system_sl.services import BackgroundServiceController
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -77,6 +78,17 @@ class MainWindow(QMainWindow):
 
 def main():
     app = QApplication(sys.argv)
+
+    # Background notifier mode: the autostart systemd unit launches the app with
+    # `--bg`. In this mode we run ONLY the hourly task notifier, never the main
+    # menu. Opening the menu here would make the always-restarting service
+    # reopen it every time it was closed.
+    if "--bg" in sys.argv:
+        view = SystemNotification()
+        controller = BackgroundServiceController(view)
+        controller.poll_and_render_task()
+        sys.exit(app.exec())
+
     app.setStyleSheet(SOLO_LEVELING_QSS)
     window = MainWindow()
     window.show()

--- a/src/system_sl/frontend/gui/popup_windows.py
+++ b/src/system_sl/frontend/gui/popup_windows.py
@@ -18,7 +18,11 @@ from system_sl.core.tasks import (
     mark_task_completed,
     remove_tasks,
 )
-from system_sl.core.prioritization import prioritize_tasks, record_reorder_feedback
+from system_sl.core.prioritization import (
+    prioritize_tasks,
+    record_reorder_feedback,
+    save_manual_order,
+)
 
 
 # GUI-added tasks no longer carry a user-chosen category — the model assigns one
@@ -157,6 +161,8 @@ class TasksWindow(QWidget):
         feedback = record_reorder_feedback(moved_title, old_rank, new_rank, new_order)
 
         self._order = new_order_dicts
+        # Persist the new order so it survives closing/reopening the window.
+        save_manual_order(self._order)
         self._render(self._order)
         self.status_label.setText(
             f"Reordered '{feedback['moved_title']}': rank "

--- a/src/system_sl/utils/notifications_ui.py
+++ b/src/system_sl/utils/notifications_ui.py
@@ -71,7 +71,7 @@ class SystemNotification(QWidget):
 
     def display_message(self, category: str, message: str) -> None:
         self.cat_label.setText(f"[ {category.upper()} ]")
-        self.msg_label.setText(title)
+        self.msg_label.setText(message)
         self.show_system_style()
 
     def show_system_style(self):


### PR DESCRIPTION
- main(): branch on --bg to run only the background notifier instead of the main menu, so the Restart=always systemd unit no longer reopens the menu on every close (infinite loop when autostart was enabled)
- notifications_ui: fix NameError in display_message (title -> message) that crashed the notifier and re-triggered the restart loop
- prioritization: add save_manual_order/load_manual_order (task_order.json) and apply the saved drag order in prioritize_tasks; TasksWindow now persists the order after a drag so it survives close/reopen
- update CLAUDE.md to the canonical src/system_sl/ layout