### PR TITLE
fix: prevent ghost notifications for removed/completed tasks

### DIFF
--- a/src/system_sl/core/priority_engine_new.py
+++ b/src/system_sl/core/priority_engine_new.py
@@ -655,6 +655,7 @@ def run_prioritization(display: bool = True, use_thompson: bool = False) -> dict
         user_vec = Fusion().build_user_vector()
     except Exception as e:
         print(f"\n[ERROR] Could not build user vector: {e}")
+        save_manual_order([])
         return PriorityPipeline()._empty_result("Vector generation failed")
 
     pipeline = PriorityPipeline(use_thompson_sampling=use_thompson)

--- a/src/system_sl/core/tasks.py
+++ b/src/system_sl/core/tasks.py
@@ -141,7 +141,27 @@ def remove_tasks(task_title: str, task_type: str = "none"):
     #     tasks.pop(task_type)
 
     save_tasks(tasks)
+    _remove_from_task_order(task_title)
     return task_title
+
+
+def _remove_from_task_order(task_title: str) -> None:
+    """Strips a task title from the persisted manual ordering file.
+
+    Args:
+        task_title (str): The exact title to remove from the order list.
+    """
+    order_data = load_data(TASK_ORDER_FILE_PATH)
+    if not isinstance(order_data, dict) or "order" not in order_data:
+        return
+    current_order = order_data["order"]
+    filtered = [t for t in current_order if t != task_title]
+    if len(filtered) != len(current_order):
+        try:
+            with open(Path(TASK_ORDER_FILE_PATH), "w") as f:
+                json.dump({"order": filtered}, f)
+        except Exception:
+            pass
 
 
 def get_random_task():
@@ -172,22 +192,26 @@ def save_manual_order(tasks: list) -> None:
 
 
 def get_topn_task():
-    """Picks an outstanding item completely at random across all non-empty active categories.
+    """Returns up to 3 task titles from the persisted manual order.
+
+    Cross-validates against current active tasks to prevent ghost notifications
+    for tasks that have been removed or completed.
 
     Returns:
-        tuple[str, str] or None: A tuple mapping (category, task_title) if items exist, otherwise None.
+        list[str]: Up to 3 task titles, filtered to only include active tasks.
     """
-    tasks = load_tasks()
-    if len(load_data(TASK_ORDER_FILE_PATH)) == 0:
-        save_manual_order(tasks)
-    task_order = load_data(TASK_ORDER_FILE_PATH) 
-    ntasks = task_order['order']
-    if len(ntasks) >= 3:
-        task = ntasks[:3]
-    else:
-        task = ntasks
+    active_tasks = load_tasks()
+    active_titles = {t["title"] for t in active_tasks if isinstance(t, dict)}
 
-    return task
+    order_data = load_data(TASK_ORDER_FILE_PATH)
+    if not isinstance(order_data, dict) or "order" not in order_data or len(order_data["order"]) == 0:
+        save_manual_order(active_tasks)
+        order_data = load_data(TASK_ORDER_FILE_PATH)
+
+    ntasks = order_data.get("order", [])
+    ntasks = [t for t in ntasks if t in active_titles]
+
+    return ntasks[:3]
 
 
 def load_completed_tasks():


### PR DESCRIPTION
## Bug
Notifications fire for tasks even after they are removed or completed from the list.

## Root Cause
The background notification service reads task order from `task_order.json`, but:
1. `remove_tasks()` only edits `tasks.json` — never touches `task_order.json`
2. `get_topn_task()` blindly trusts `task_order.json` without validating against active tasks
3. `run_prioritization()` can fail silently (e.g. missing persona/SpaCy) and leave stale data in `task_order.json` indefinitely

## Fixes
- **`remove_tasks()`**: Now calls `_remove_from_task_order()` to strip the removed task from `task_order.json`
- **`get_topn_task()`**: Cross-validates order entries against current active tasks before returning
- **`run_prioritization()`**: Clears `task_order.json` on vector-build failure so stale data cannot linger